### PR TITLE
[PR] Task unit testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Quality Gate Status](http://186.23.126.152:9000/api/project_badges/measure?project=StudentCompass&metric=alert_status&token=sqb_c77648187b7b050cc75d196eaebf6b094b1fd5a0)](http://186.23.126.152:9000/dashboard?id=StudentCompass)
-
 # StudentCompass
 
 ## Overview

--- a/web-api/StudentCompass.Services/Services/ProgressService.cs
+++ b/web-api/StudentCompass.Services/Services/ProgressService.cs
@@ -65,11 +65,11 @@ namespace StudentCompass.Services.Services
                 else
                 {
                     correlativesDict.TryGetValue(subjectCourse.Code, out var correlatives);
+                    var allCorrelativesApproved = correlatives == null || correlatives.All(c => approvedSubjects.Exists(sc => sc.Code == c));
 
-                    if (correlatives == null || approvedSubjects.All(sc => correlatives.Contains(sc.Code)))
-                        subjectCourseDto.Status = AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available);
-                    else
-                        subjectCourseDto.Status = AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable);
+                    subjectCourseDto.Status = allCorrelativesApproved ?
+                        AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available) :
+                        AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable);
                 }
                 result.Add(subjectCourseDto);
             }

--- a/web-api/StudentCompass.ServicesTests/ProgressServiceTests.cs
+++ b/web-api/StudentCompass.ServicesTests/ProgressServiceTests.cs
@@ -90,6 +90,241 @@ namespace StudentCompass.ServicesTests
             Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
         }
 
+        // No approved subjects, one correlative unavailable and one available
+        [Fact]
+        public void GetProgressOverview_OneCorrelativeAndNoApprovedSubjects_ReturnsStatus()
+        {
+            // Arrange
+            const short studentId = 1;
+            const byte careerPlanId = 1;
+            _progressRepositoryMock
+                .Setup(x => x.GetEnrollByStudentAndCareer(studentId, careerPlanId))
+                .Returns(Task.FromResult<(short, byte)?>((studentId, careerPlanId)));
+
+            var subjectCourses = new List<SubjectCourse>
+            {
+                CreateSubjectCourse(1, null, null, careerPlanId, null),
+                CreateSubjectCourse(2, null, null, careerPlanId, null),
+                CreateSubjectCourse(3, null, null, careerPlanId, null)
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetProgressOverviewCourses(studentId, careerPlanId))
+                .Returns(Task.FromResult(subjectCourses));
+
+            var correlativesDict = new Dictionary<short, List<short>>
+            {
+                { 2, new List<short> { 1 } }
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetCorrelativesByCareer(careerPlanId))
+                .Returns(Task.FromResult(correlativesDict));
+
+            // Act
+            var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
+
+            // Assert
+            Assert.Equal(result[0].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
+            Assert.Equal(result[1].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable));
+            Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
+        }
+
+        // No approved subjects, two correlatives unavailable from different subjects
+        [Fact]
+        public void GetProgressOverview_TwoCorrelativesAndNoApprovedSubjectsFromDifferentSubjects_ReturnsStatus()
+        {
+            // Arrange
+            const short studentId = 1;
+            const byte careerPlanId = 1;
+            _progressRepositoryMock
+                .Setup(x => x.GetEnrollByStudentAndCareer(studentId, careerPlanId))
+                .Returns(Task.FromResult<(short, byte)?>((studentId, careerPlanId)));
+
+            var subjectCourses = new List<SubjectCourse>
+            {
+                CreateSubjectCourse(1, null, null, careerPlanId, null),
+                CreateSubjectCourse(2, null, null, careerPlanId, null),
+                CreateSubjectCourse(3, null, null, careerPlanId, null),
+                CreateSubjectCourse(4, null, null, careerPlanId, null),
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetProgressOverviewCourses(studentId, careerPlanId))
+                .Returns(Task.FromResult(subjectCourses));
+
+            var correlativesDict = new Dictionary<short, List<short>>
+            {
+                { 2, new List<short> { 1 } },
+                { 4, new List<short> { 3 } }
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetCorrelativesByCareer(careerPlanId))
+                .Returns(Task.FromResult(correlativesDict));
+
+            // Act
+            var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
+
+            // Assert
+            Assert.Equal(result[0].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
+            Assert.Equal(result[1].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable));
+            Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
+            Assert.Equal(result[3].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable));
+        }
+
+        // No approved subjects, two correlatives unavailable from the same subjects
+        [Fact]
+        public void GetProgressOverview_TwoCorrelativesAndNoApprovedSubjectsFromSameSubjects_ReturnsStatus()
+        {
+            // Arrange
+            const short studentId = 1;
+            const byte careerPlanId = 1;
+            _progressRepositoryMock
+                .Setup(x => x.GetEnrollByStudentAndCareer(studentId, careerPlanId))
+                .Returns(Task.FromResult<(short, byte)?>((studentId, careerPlanId)));
+
+            var subjectCourses = new List<SubjectCourse>
+            {
+                CreateSubjectCourse(1, null, null, careerPlanId, null),
+                CreateSubjectCourse(2, null, null, careerPlanId, null),
+                CreateSubjectCourse(3, null, null, careerPlanId, null),
+                CreateSubjectCourse(4, null, null, careerPlanId, null),
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetProgressOverviewCourses(studentId, careerPlanId))
+                .Returns(Task.FromResult(subjectCourses));
+
+            var correlativesDict = new Dictionary<short, List<short>>
+            {
+                { 2, new List<short> { 1 } },
+                { 4, new List<short> { 1 } }
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetCorrelativesByCareer(careerPlanId))
+                .Returns(Task.FromResult(correlativesDict));
+
+            // Act
+            var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
+
+            // Assert
+            Assert.Equal(result[0].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
+            Assert.Equal(result[1].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable));
+            Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
+            Assert.Equal(result[3].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable));
+        }
+
+        // No approved subjects and one subject needs two correlatives
+        [Fact]
+        public void GetProgressOverview_TwoCorrelativesInSameSubject_ReturnsStatus()
+        {
+            // Arrange
+            const short studentId = 1;
+            const byte careerPlanId = 1;
+            _progressRepositoryMock
+                .Setup(x => x.GetEnrollByStudentAndCareer(studentId, careerPlanId))
+                .Returns(Task.FromResult<(short, byte)?>((studentId, careerPlanId)));
+
+            var subjectCourses = new List<SubjectCourse>
+            {
+                CreateSubjectCourse(1, null, null, careerPlanId, null),
+                CreateSubjectCourse(2, null, null, careerPlanId, null),
+                CreateSubjectCourse(3, null, null, careerPlanId, null),
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetProgressOverviewCourses(studentId, careerPlanId))
+                .Returns(Task.FromResult(subjectCourses));
+
+            var correlativesDict = new Dictionary<short, List<short>>
+            {
+                { 3, new List<short> { 1,2 } },
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetCorrelativesByCareer(careerPlanId))
+                .Returns(Task.FromResult(correlativesDict));
+
+            // Act
+            var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
+
+            // Assert
+            Assert.Equal(result[0].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
+            Assert.Equal(result[1].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
+            Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable));
+        }
+
+        // Approved subjects but no correlatives
+        [Fact]
+        public void GetProgressOverview_NoCorrelativesAndAllApprovedSubjects_ReturnsAllApproved()
+        {
+            // Arrange
+            const short studentId = 1;
+            const byte careerPlanId = 1;
+            _progressRepositoryMock
+                .Setup(x => x.GetEnrollByStudentAndCareer(studentId, careerPlanId))
+                .Returns(Task.FromResult<(short, byte)?>((studentId, careerPlanId)));
+
+            var subjectCourses = new List<SubjectCourse>
+            {
+                CreateSubjectCourse(1, 10, 1, careerPlanId, CourseStatus.Approved),
+                CreateSubjectCourse(2, 10, 1, careerPlanId, CourseStatus.Approved),
+                CreateSubjectCourse(3, 10, 1, careerPlanId, CourseStatus.Approved)
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetProgressOverviewCourses(studentId, careerPlanId))
+                .Returns(Task.FromResult(subjectCourses));
+
+            var correlativesDict = new Dictionary<short, List<short>>();
+            _progressRepositoryMock
+                .Setup(x => x.GetCorrelativesByCareer(careerPlanId))
+                .Returns(Task.FromResult(correlativesDict));
+
+            // Act
+            var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
+
+            // Assert
+            Assert.Equal(result[0].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
+            Assert.Equal(result[1].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
+            Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
+        }
+
+        // Approved subjects but with correlatives
+        [Fact]
+        public void GetProgressOverview_CorrelativesAndAllApprovedSubjects_ReturnsAllApproved()
+        {
+            // Arrange
+            const short studentId = 1;
+            const byte careerPlanId = 1;
+            _progressRepositoryMock
+                .Setup(x => x.GetEnrollByStudentAndCareer(studentId, careerPlanId))
+                .Returns(Task.FromResult<(short, byte)?>((studentId, careerPlanId)));
+
+            var subjectCourses = new List<SubjectCourse>
+            {
+                CreateSubjectCourse(1, 10, 1, careerPlanId, CourseStatus.Approved),
+                CreateSubjectCourse(2, 10, 1, careerPlanId, CourseStatus.Approved),
+                CreateSubjectCourse(3, 10, 1, careerPlanId, CourseStatus.Approved),
+                CreateSubjectCourse(4, 10, 1, careerPlanId, CourseStatus.Approved)
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetProgressOverviewCourses(studentId, careerPlanId))
+                .Returns(Task.FromResult(subjectCourses));
+
+            var correlativesDict = new Dictionary<short, List<short>>
+            {
+                { 2, new List<short> { 1 } },
+                { 3, new List<short> { 1 } },
+                { 4, new List<short> { 1, 2, 3 } }
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetCorrelativesByCareer(careerPlanId))
+                .Returns(Task.FromResult(correlativesDict));
+
+            // Act
+            var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
+
+            // Assert
+            Assert.Equal(result[0].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
+            Assert.Equal(result[1].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
+            Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
+            Assert.Equal(result[3].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
+        }
+
         #endregion
 
         #region CreateMethods

--- a/web-api/StudentCompass.ServicesTests/ProgressServiceTests.cs
+++ b/web-api/StudentCompass.ServicesTests/ProgressServiceTests.cs
@@ -55,9 +55,9 @@ namespace StudentCompass.ServicesTests
             Assert.ThrowsAsync<ArgumentException>(() => _progressService.GetProgressOverview(studentId, careerPlanId));
         }
 
-        // No correlatives and no approved subjects
+        // No correlatives and no courses
         [Fact]
-        public void GetProgressOverview_EmptyCorrelativesAndNoApprovedSubjects_ReturnsAllAvailable()
+        public void GetProgressOverview_EmptyCorrelativesAndNoCourses_ReturnsAllAvailable()
         {
             // Arrange
             const short studentId = 1;
@@ -85,14 +85,15 @@ namespace StudentCompass.ServicesTests
             var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
 
             // Assert
-            Assert.Equal(result[0].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
-            Assert.Equal(result[1].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
-            Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[0].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[1].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[2].Status);
+
         }
 
-        // No approved subjects, one correlative unavailable and one available
+        // No courses, one correlative unavailable and one available
         [Fact]
-        public void GetProgressOverview_OneCorrelativeAndNoApprovedSubjects_ReturnsStatus()
+        public void GetProgressOverview_OneCorrelativeAndNoCourses_ReturnsStatus()
         {
             // Arrange
             const short studentId = 1;
@@ -123,14 +124,14 @@ namespace StudentCompass.ServicesTests
             var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
 
             // Assert
-            Assert.Equal(result[0].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
-            Assert.Equal(result[1].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable));
-            Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[0].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable), result[1].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[2].Status);
         }
 
-        // No approved subjects, two correlatives unavailable from different subjects
+        // No courses, two correlatives unavailable from different subjects
         [Fact]
-        public void GetProgressOverview_TwoCorrelativesAndNoApprovedSubjectsFromDifferentSubjects_ReturnsStatus()
+        public void GetProgressOverview_TwoCorrelativesAndNoCoursesFromDifferentSubjects_ReturnsStatus()
         {
             // Arrange
             const short studentId = 1;
@@ -163,15 +164,15 @@ namespace StudentCompass.ServicesTests
             var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
 
             // Assert
-            Assert.Equal(result[0].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
-            Assert.Equal(result[1].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable));
-            Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
-            Assert.Equal(result[3].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable));
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[0].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable), result[1].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[2].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable), result[3].Status);
         }
 
-        // No approved subjects, two correlatives unavailable from the same subjects
+        // No courses, two correlatives unavailable from the same subjects
         [Fact]
-        public void GetProgressOverview_TwoCorrelativesAndNoApprovedSubjectsFromSameSubjects_ReturnsStatus()
+        public void GetProgressOverview_TwoCorrelativesAndNoCoursesFromSameSubjects_ReturnsStatus()
         {
             // Arrange
             const short studentId = 1;
@@ -204,13 +205,13 @@ namespace StudentCompass.ServicesTests
             var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
 
             // Assert
-            Assert.Equal(result[0].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
-            Assert.Equal(result[1].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable));
-            Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
-            Assert.Equal(result[3].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable));
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[0].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable), result[1].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[2].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable), result[3].Status);
         }
 
-        // No approved subjects and one subject needs two correlatives
+        // No courses and one subject needs two correlatives
         [Fact]
         public void GetProgressOverview_TwoCorrelativesInSameSubject_ReturnsStatus()
         {
@@ -243,9 +244,166 @@ namespace StudentCompass.ServicesTests
             var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
 
             // Assert
-            Assert.Equal(result[0].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
-            Assert.Equal(result[1].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available));
-            Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable));
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[0].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[1].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable), result[2].Status);
+        }
+
+        // In progress subject with no correlatives
+        [Fact]
+        public void GetProgressOverview_NoCorrelativesAndInProgressSubject_ReturnsInProgress()
+        {
+            // Arrange
+            const short studentId = 1;
+            const byte careerPlanId = 1;
+            _progressRepositoryMock
+                .Setup(x => x.GetEnrollByStudentAndCareer(studentId, careerPlanId))
+                .Returns(Task.FromResult<(short, byte)?>((studentId, careerPlanId)));
+
+            var subjectCourses = new List<SubjectCourse>
+            {
+                CreateSubjectCourse(1, null, null, careerPlanId, CourseStatus.InProgress),
+                CreateSubjectCourse(2, null, null, careerPlanId, null),
+                CreateSubjectCourse(3, null, null, careerPlanId, null),
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetProgressOverviewCourses(studentId, careerPlanId))
+                .Returns(Task.FromResult(subjectCourses));
+
+            var correlativesDict = new Dictionary<short, List<short>>();
+            _progressRepositoryMock
+                .Setup(x => x.GetCorrelativesByCareer(careerPlanId))
+                .Returns(Task.FromResult(correlativesDict));
+
+            // Act
+            var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
+
+            // Assert
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.InProgress), result[0].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[1].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[2].Status);
+        }
+
+        // In progress with unrelated correlatives
+        [Fact]
+        public void GetProgressOverview_UnrelatedCorrelativesAndInProgressSubject_ReturnsInProgress()
+        {
+            // Arrange
+            const short studentId = 1;
+            const byte careerPlanId = 1;
+            _progressRepositoryMock
+                .Setup(x => x.GetEnrollByStudentAndCareer(studentId, careerPlanId))
+                .Returns(Task.FromResult<(short, byte)?>((studentId, careerPlanId)));
+
+            var subjectCourses = new List<SubjectCourse>
+            {
+                CreateSubjectCourse(1, null, null, careerPlanId, CourseStatus.InProgress),
+                CreateSubjectCourse(2, null, null, careerPlanId, null),
+                CreateSubjectCourse(3, null, null, careerPlanId, null),
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetProgressOverviewCourses(studentId, careerPlanId))
+                .Returns(Task.FromResult(subjectCourses));
+
+            var correlativesDict = new Dictionary<short, List<short>>
+            {
+                { 3, new List<short> { 2 } },
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetCorrelativesByCareer(careerPlanId))
+                .Returns(Task.FromResult(correlativesDict));
+
+            // Act
+            var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
+
+            // Assert
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.InProgress), result[0].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[1].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable), result[2].Status);
+        }
+
+        // In progress subject with correlatives
+        [Fact]
+        public void GetProgressOverview_CorrelativesAndInProgressSubject_ReturnsInProgress()
+        {
+            // Arrange
+            const short studentId = 1;
+            const byte careerPlanId = 1;
+            _progressRepositoryMock
+                .Setup(x => x.GetEnrollByStudentAndCareer(studentId, careerPlanId))
+                .Returns(Task.FromResult<(short, byte)?>((studentId, careerPlanId)));
+
+            var subjectCourses = new List<SubjectCourse>
+            {
+                CreateSubjectCourse(1, null, 1, careerPlanId, CourseStatus.InProgress),
+                CreateSubjectCourse(2, null, null, careerPlanId, null),
+                CreateSubjectCourse(3, null, null, careerPlanId, null),
+                CreateSubjectCourse(4, null, null, careerPlanId, null),
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetProgressOverviewCourses(studentId, careerPlanId))
+                .Returns(Task.FromResult(subjectCourses));
+
+            var correlativesDict = new Dictionary<short, List<short>>
+            {
+                { 2, new List<short> { 1 } },
+                { 3, new List<short> { 1 } },
+                { 4, new List<short> { 1, 2, 3 } }
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetCorrelativesByCareer(careerPlanId))
+                .Returns(Task.FromResult(correlativesDict));
+
+            // Act
+            var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
+
+            // Assert
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.InProgress), result[0].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable), result[1].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable), result[2].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable), result[3].Status);
+        }
+
+        // One approved and one in progress subject with correlatives
+        [Fact]
+        public void GetProgressOverview_CorrelativesAndOneApprovedSubject_ReturnsStatus()
+        {
+            // Arrange
+            const short studentId = 1;
+            const byte careerPlanId = 1;
+            _progressRepositoryMock
+                .Setup(x => x.GetEnrollByStudentAndCareer(studentId, careerPlanId))
+                .Returns(Task.FromResult<(short, byte)?>((studentId, careerPlanId)));
+
+            var subjectCourses = new List<SubjectCourse>
+            {
+                CreateSubjectCourse(1, 10, 1, careerPlanId, CourseStatus.Approved),
+                CreateSubjectCourse(2, null, 2, careerPlanId, CourseStatus.InProgress),
+                CreateSubjectCourse(3, null, null, careerPlanId, null),
+                CreateSubjectCourse(4, null, null, careerPlanId, null),
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetProgressOverviewCourses(studentId, careerPlanId))
+                .Returns(Task.FromResult(subjectCourses));
+
+            var correlativesDict = new Dictionary<short, List<short>>
+            {
+                { 2, new List<short> { 1 } },
+                { 3, new List<short> { 1 } },
+                { 4, new List<short> { 2 } }
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetCorrelativesByCareer(careerPlanId))
+                .Returns(Task.FromResult(correlativesDict));
+
+            // Act
+            var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
+
+            // Assert
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved), result[0].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.InProgress), result[1].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[2].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable), result[3].Status);
         }
 
         // Approved subjects but no correlatives
@@ -278,9 +436,9 @@ namespace StudentCompass.ServicesTests
             var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
 
             // Assert
-            Assert.Equal(result[0].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
-            Assert.Equal(result[1].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
-            Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved), result[0].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved), result[1].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved), result[2].Status);
         }
 
         // Approved subjects but with correlatives
@@ -319,10 +477,103 @@ namespace StudentCompass.ServicesTests
             var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
 
             // Assert
-            Assert.Equal(result[0].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
-            Assert.Equal(result[1].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
-            Assert.Equal(result[2].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
-            Assert.Equal(result[3].Status, AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved));
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved), result[0].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved), result[1].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved), result[2].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved), result[3].Status);
+        }
+
+        // One approved subject, one correlative made available
+        [Fact]
+        public void GetProgressOverview_TwoCorrelativesAndNoApprovedSubjectsFromSameSubjects_ReturnsStatu()
+        {
+            // Arrange
+            const short studentId = 1;
+            const byte careerPlanId = 1;
+            _progressRepositoryMock
+                .Setup(x => x.GetEnrollByStudentAndCareer(studentId, careerPlanId))
+                .Returns(Task.FromResult<(short, byte)?>((studentId, careerPlanId)));
+
+            var subjectCourses = new List<SubjectCourse>
+            {
+                CreateSubjectCourse(1, null, 1, careerPlanId, CourseStatus.Approved),
+                CreateSubjectCourse(2, null, null, careerPlanId, null),
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetProgressOverviewCourses(studentId, careerPlanId))
+                .Returns(Task.FromResult(subjectCourses));
+
+            var correlativesDict = new Dictionary<short, List<short>>
+            {
+                { 2, new List<short> { 1 } },
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetCorrelativesByCareer(careerPlanId))
+                .Returns(Task.FromResult(correlativesDict));
+
+            // Act
+            var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
+
+            // Assert
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved), result[0].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[1].Status);
+        }
+
+        // Three approved subjects and two in progress with correlatives
+        [Fact]
+        public void GetProgressOverview_CorrelativesAndApprovedAndInProgressSubjects_ReturnsStatus()
+        {
+            // Arrange
+            const short studentId = 1;
+            const byte careerPlanId = 1;
+            _progressRepositoryMock
+                .Setup(x => x.GetEnrollByStudentAndCareer(studentId, careerPlanId))
+                .Returns(Task.FromResult<(short, byte)?>((studentId, careerPlanId)));
+
+            var subjectCourses = new List<SubjectCourse>
+            {
+                CreateSubjectCourse(1, 10, 1, careerPlanId, CourseStatus.Approved),
+                CreateSubjectCourse(2, 10, 2, careerPlanId, CourseStatus.Approved),
+                CreateSubjectCourse(3, 10, 3, careerPlanId, CourseStatus.Approved),
+                CreateSubjectCourse(4, null, 4, careerPlanId, CourseStatus.InProgress),
+                CreateSubjectCourse(5, null, 5, careerPlanId, CourseStatus.InProgress),
+                CreateSubjectCourse(6, null, null, careerPlanId, null),
+                CreateSubjectCourse(7, null, null, careerPlanId, null),
+                CreateSubjectCourse(8, null, null, careerPlanId, null),
+                CreateSubjectCourse(9, null, null, careerPlanId, null),
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetProgressOverviewCourses(studentId, careerPlanId))
+                .Returns(Task.FromResult(subjectCourses));
+
+            var correlativesDict = new Dictionary<short, List<short>>
+            {
+                { 2, new List<short> { 1 } },
+                { 3, new List<short> { 2, 3 } },
+                { 4, new List<short> { 1 } },
+                { 5, new List<short> { 3 } },
+                { 6, new List<short> { 1 } },
+                { 7, new List<short> { 1, 4 } },
+                { 8, new List<short> { 4, 5 } }
+            };
+            _progressRepositoryMock
+                .Setup(x => x.GetCorrelativesByCareer(careerPlanId))
+                .Returns(Task.FromResult(correlativesDict));
+
+            // Act
+            var result = _progressService.GetProgressOverview(studentId, careerPlanId).Result.ToList();
+
+            // Assert
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved), result[0].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved), result[1].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Approved), result[2].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.InProgress), result[3].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.InProgress), result[4].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[5].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable), result[6].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.NotAvailable), result[7].Status);
+            Assert.Equal(AcademicHelpers.GetStatusDescription((byte)CourseStatus.Available), result[8].Status);
+
         }
 
         #endregion

--- a/web-api/StudentCompass.ServicesTests/ProgressTests/GetProgressOverviewTests.cs
+++ b/web-api/StudentCompass.ServicesTests/ProgressTests/GetProgressOverviewTests.cs
@@ -5,14 +5,14 @@ using StudentCompass.Data.Helpers;
 using StudentCompass.Services.Contracts;
 using StudentCompass.Services.Services;
 
-namespace StudentCompass.ServicesTests
+namespace StudentCompass.ServicesTests.ProgressTests
 {
-    public class ProgressServiceTests
+    public class GetProgressOverviewTests
     {
         private readonly Mock<IProgressRepository> _progressRepositoryMock = new();
         private readonly IProgressService _progressService;
 
-        public ProgressServiceTests()
+        public GetProgressOverviewTests()
         {
             _progressService = new ProgressService(_progressRepositoryMock.Object);
         }

--- a/web-api/StudentCompass.ServicesTests/ProgressTests/UpdateSubjectsTests.cs
+++ b/web-api/StudentCompass.ServicesTests/ProgressTests/UpdateSubjectsTests.cs
@@ -1,0 +1,20 @@
+﻿using Moq;
+using StudentCompass.Data.Contracts;
+using StudentCompass.Services.Contracts;
+using StudentCompass.Services.Services;
+
+namespace StudentCompass.ServicesTests.ProgressTests
+{
+    public class UpdateSubjectsTests
+    {
+        private readonly Mock<IProgressRepository> _progressRepositoryMock = new();
+        private readonly IProgressService _progressService;
+
+        public UpdateSubjectsTests()
+        {
+            _progressService = new ProgressService(_progressRepositoryMock.Object);
+        }
+
+
+    }
+}


### PR DESCRIPTION
- Se agregan tests para los services, pero estructurados en archivos según métodos.
- Se remueve temporalmente el SonarQube badge del README.md